### PR TITLE
feat: add file_dependencies and missing_dependencies API

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Test cases are located in `./src/tests`, fixtures are located in `./tests`
 
 - [x] alias.test.js
 - [x] browserField.test.js
-- [ ] dependencies.test.js
+- [x] dependencies.test.js
 - [x] exportsField.test.js
 - [x] extension-alias.test.js
 - [x] extensions.test.js
@@ -97,7 +97,7 @@ Test cases are located in `./src/tests`, fixtures are located in `./tests`
 - [x] identifier.test.js (see unit test in `crates/oxc_resolver/src/request.rs`)
 - [x] importsField.test.js
 - [x] incorrect-description-file.test.js (need to add ctx.fileDependencies)
-- [ ] missing.test.js
+- [x] missing.test.js
 - [x] path.test.js (see unit test in `crates/oxc_resolver/src/path.rs`)
 - [ ] plugins.test.js
 - [ ] pnp.test.js

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -14,8 +14,8 @@ use dashmap::{DashMap, DashSet};
 use rustc_hash::FxHasher;
 
 use crate::{
-    package_json::PackageJson, path::PathUtil, FileMetadata, FileSystem, ResolveError,
-    ResolveOptions, TsConfig,
+    context::ResolveContext as Ctx, package_json::PackageJson, path::PathUtil, FileMetadata,
+    FileSystem, ResolveError, ResolveOptions, TsConfig,
 };
 
 #[derive(Default)]
@@ -176,12 +176,22 @@ impl CachedPathImpl {
         *self.meta.get_or_init(|| fs.metadata(&self.path).ok())
     }
 
-    pub fn is_file<Fs: FileSystem>(&self, fs: &Fs) -> bool {
-        self.meta(fs).is_some_and(|meta| meta.is_file)
+    pub fn is_file<Fs: FileSystem>(&self, fs: &Fs, ctx: &mut Ctx) -> bool {
+        let yes = self.meta(fs).is_some_and(|meta| meta.is_file);
+        if yes {
+            ctx.add_file_dependency(self.path());
+        } else {
+            ctx.add_missing_dependency(self.path());
+        }
+        yes
     }
 
-    pub fn is_dir<Fs: FileSystem>(&self, fs: &Fs) -> bool {
-        self.meta(fs).is_some_and(|meta| meta.is_dir)
+    pub fn is_dir<Fs: FileSystem>(&self, fs: &Fs, ctx: &mut Ctx) -> bool {
+        let yes = self.meta(fs).is_some_and(|meta| meta.is_dir);
+        if !yes {
+            ctx.add_missing_dependency(self.path());
+        }
+        yes
     }
 
     fn symlink<Fs: FileSystem>(&self, fs: &Fs) -> io::Result<Option<PathBuf>> {
@@ -219,16 +229,18 @@ impl CachedPathImpl {
         &self,
         module_name: &str,
         cache: &Cache<Fs>,
+        ctx: &mut Ctx,
     ) -> Option<CachedPath> {
         let cached_path = cache.value(&self.path.join(module_name));
-        cached_path.is_dir(&cache.fs).then(|| cached_path)
+        cached_path.is_dir(&cache.fs, ctx).then(|| cached_path)
     }
 
     pub fn cached_node_modules<Fs: FileSystem + Default>(
         &self,
         cache: &Cache<Fs>,
+        ctx: &mut Ctx,
     ) -> Option<CachedPath> {
-        self.node_modules.get_or_init(|| self.module_directory("node_modules", cache)).clone()
+        self.node_modules.get_or_init(|| self.module_directory("node_modules", cache, ctx)).clone()
     }
 
     /// Find package.json of a path by traversing parent directories.
@@ -240,10 +252,11 @@ impl CachedPathImpl {
         &self,
         fs: &Fs,
         options: &ResolveOptions,
+        ctx: &mut Ctx,
     ) -> Result<Option<Arc<PackageJson>>, ResolveError> {
         let mut cache_value = self;
         // Go up directories when the querying path is not a directory
-        while !cache_value.is_dir(fs) {
+        while !cache_value.is_dir(fs, ctx) {
             if let Some(cv) = &cache_value.parent {
                 cache_value = cv.as_ref();
             } else {
@@ -252,7 +265,7 @@ impl CachedPathImpl {
         }
         let mut cache_value = Some(cache_value);
         while let Some(cv) = cache_value {
-            if let Some(package_json) = cv.package_json(fs, options)? {
+            if let Some(package_json) = cv.package_json(fs, options, ctx)? {
                 return Ok(Some(Arc::clone(&package_json)));
             }
             cache_value = cv.parent.as_deref();
@@ -269,9 +282,11 @@ impl CachedPathImpl {
         &self,
         fs: &Fs,
         options: &ResolveOptions,
+        ctx: &mut Ctx,
     ) -> Result<Option<Arc<PackageJson>>, ResolveError> {
         // Change to `std::sync::OnceLock::get_or_try_init` when it is stable.
-        self.package_json
+        let result = self
+            .package_json
             .get_or_try_init(|| {
                 let package_json_path = self.path.join("package.json");
                 let Ok(package_json_string) = fs.read_to_string(&package_json_path) else {
@@ -292,7 +307,25 @@ impl CachedPathImpl {
                 .map(Some)
                 .map_err(|error| ResolveError::from_serde_json_error(package_json_path, &error))
             })
-            .cloned()
+            .cloned();
+        // https://github.com/webpack/enhanced-resolve/blob/58464fc7cb56673c9aa849e68e6300239601e615/lib/DescriptionFileUtils.js#L68-L82
+        match &result {
+            Ok(Some(package_json)) => {
+                ctx.add_file_dependency(&package_json.path);
+            }
+            Ok(None) => {
+                // Avoid an allocation by making this lazy
+                if let Some(deps) = &mut ctx.missing_dependencies {
+                    deps.push(self.path.join("package.json"));
+                }
+            }
+            Err(_) => {
+                if let Some(deps) = &mut ctx.file_dependencies {
+                    deps.push(self.path.join("package.json"));
+                }
+            }
+        }
+        result
     }
 }
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,4 +1,7 @@
-use std::ops::{Deref, DerefMut};
+use std::{
+    ops::{Deref, DerefMut},
+    path::{Path, PathBuf},
+};
 
 use crate::error::ResolveError;
 
@@ -8,10 +11,20 @@ pub struct ResolveContext(ResolveContextImpl);
 #[derive(Debug, Default, Clone)]
 pub struct ResolveContextImpl {
     pub fully_specified: bool,
+
     pub query: Option<String>,
+
     pub fragment: Option<String>,
+
+    /// Files that was found on file system
+    pub file_dependencies: Option<Vec<PathBuf>>,
+
+    /// Files that was found on file system
+    pub missing_dependencies: Option<Vec<PathBuf>>,
+
     /// The current resolving alias for bailing recursion alias.
     pub resolving_alias: Option<String>,
+
     /// For avoiding infinite recursion, which will cause stack overflow.
     depth: u8,
 }
@@ -41,6 +54,23 @@ impl ResolveContext {
         }
         if let Some(fragment) = fragment {
             self.fragment.replace(fragment.to_string());
+        }
+    }
+
+    pub fn init_file_dependencies(&mut self) {
+        self.file_dependencies.replace(vec![]);
+        self.missing_dependencies.replace(vec![]);
+    }
+
+    pub fn add_file_dependency(&mut self, dep: &Path) {
+        if let Some(deps) = &mut self.file_dependencies {
+            deps.push(dep.to_path_buf());
+        }
+    }
+
+    pub fn add_missing_dependency(&mut self, dep: &Path) {
+        if let Some(deps) = &mut self.missing_dependencies {
+            deps.push(dep.to_path_buf());
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -588,10 +588,8 @@ impl<Fs: FileSystem + Default> ResolverGeneric<Fs> {
             return Ok(Some(path));
         }
         if cached_path.is_file(&self.cache.fs, ctx) {
-            // ctx.add_file_dependency(cached_path.path());
             return Ok(Some(cached_path.clone()));
         }
-        // ctx.add_missing_dependency(cached_path.path());
         Ok(None)
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,6 +37,7 @@ mod tsconfig;
 #[cfg(test)]
 mod tests;
 
+use rustc_hash::FxHashSet;
 use std::{
     borrow::Cow,
     cmp::Ordering,
@@ -68,6 +69,15 @@ pub use crate::{
 };
 
 type ResolveResult = Result<Option<CachedPath>, ResolveError>;
+
+#[derive(Debug, Default, Clone)]
+pub struct ResolveContext {
+    /// Files that was found on file system
+    pub file_dependencies: FxHashSet<PathBuf>,
+
+    /// Dependencies that was not found on file system
+    pub missing_dependencies: FxHashSet<PathBuf>,
+}
 
 /// Resolver with the current operating system as the file system
 pub type Resolver = ResolverGeneric<FileSystemOs>;
@@ -115,7 +125,7 @@ impl<Fs: FileSystem + Default> ResolverGeneric<Fs> {
         self.cache.clear();
     }
 
-    /// Resolve `specifier` at `path`
+    /// Resolve `specifier` at absolute `path`
     ///
     /// # Errors
     ///
@@ -125,15 +135,44 @@ impl<Fs: FileSystem + Default> ResolverGeneric<Fs> {
         path: P,
         specifier: &str,
     ) -> Result<Resolution, ResolveError> {
-        self.resolve_tracing(path.as_ref(), specifier)
+        let mut ctx = Ctx::default();
+        self.resolve_tracing(path.as_ref(), specifier, &mut ctx)
+    }
+
+    /// Resolve `specifier` at absolute `path` with [ResolveContext]
+    ///
+    /// # Errors
+    ///
+    /// * See [ResolveError]
+    pub fn resolve_with_context<P: AsRef<Path>>(
+        &self,
+        path: P,
+        specifier: &str,
+        resolve_context: &mut ResolveContext,
+    ) -> Result<Resolution, ResolveError> {
+        let mut ctx = Ctx::default();
+        ctx.init_file_dependencies();
+        let result = self.resolve_tracing(path.as_ref(), specifier, &mut ctx);
+        if let Some(deps) = &mut ctx.file_dependencies {
+            resolve_context.file_dependencies.extend(deps.drain(..));
+        }
+        if let Some(deps) = &mut ctx.missing_dependencies {
+            resolve_context.missing_dependencies.extend(deps.drain(..));
+        }
+        result
     }
 
     /// Wrap `resolve_impl` with `tracing` information
-    fn resolve_tracing(&self, path: &Path, specifier: &str) -> Result<Resolution, ResolveError> {
+    fn resolve_tracing(
+        &self,
+        path: &Path,
+        specifier: &str,
+        ctx: &mut Ctx,
+    ) -> Result<Resolution, ResolveError> {
         let span = tracing::debug_span!("resolve", path = ?path, specifier = specifier);
         let _enter = span.enter();
         tracing::trace!(options = ?self.options, "resolve_options");
-        let r = self.resolve_impl(path, specifier);
+        let r = self.resolve_impl(path, specifier, ctx);
         match &r {
             Ok(r) => tracing::debug!(path = ?path, specifier = specifier, ret = ?r.path),
             Err(err) => tracing::debug!(path = ?path, specifier = specifier, err = ?err),
@@ -141,25 +180,28 @@ impl<Fs: FileSystem + Default> ResolverGeneric<Fs> {
         r
     }
 
-    fn resolve_impl(&self, path: &Path, specifier: &str) -> Result<Resolution, ResolveError> {
-        let mut ctx = Ctx::default();
+    fn resolve_impl(
+        &self,
+        path: &Path,
+        specifier: &str,
+        ctx: &mut Ctx,
+    ) -> Result<Resolution, ResolveError> {
         ctx.with_fully_specified(self.options.fully_specified);
         let specifier = Specifier::parse(specifier).map_err(ResolveError::Specifier)?;
         ctx.with_query_fragment(specifier.query, specifier.fragment);
         let cached_path = self.cache.value(path);
-        let cached_path =
-            self.require(&cached_path, specifier.path(), &mut ctx).or_else(|err| {
-                if err.is_ignore() {
-                    return Err(err);
-                }
-                // enhanced-resolve: try fallback
-                self.load_alias(&cached_path, specifier.path(), &self.options.fallback, &mut ctx)
-                    .and_then(|value| value.ok_or(err))
-            })?;
+        let cached_path = self.require(&cached_path, specifier.path(), ctx).or_else(|err| {
+            if err.is_ignore() {
+                return Err(err);
+            }
+            // enhanced-resolve: try fallback
+            self.load_alias(&cached_path, specifier.path(), &self.options.fallback, ctx)
+                .and_then(|value| value.ok_or(err))
+        })?;
         let path = self.load_realpath(&cached_path)?;
         // enhanced-resolve: restrictions
         self.check_restrictions(&path)?;
-        let package_json = cached_path.find_package_json(&self.cache.fs, &self.options)?;
+        let package_json = cached_path.find_package_json(&self.cache.fs, &self.options, ctx)?;
         if let Some(package_json) = &package_json {
             // path must be inside the package.
             debug_assert!(path.starts_with(package_json.directory()));
@@ -365,7 +407,8 @@ impl<Fs: FileSystem + Default> ResolverGeneric<Fs> {
     ) -> ResolveResult {
         // 1. Find the closest package scope SCOPE to DIR.
         // 2. If no scope was found, return.
-        let Some(package_json) = cached_path.find_package_json(&self.cache.fs, &self.options)?
+        let Some(package_json) =
+            cached_path.find_package_json(&self.cache.fs, &self.options, ctx)?
         else {
             return Ok(None);
         };
@@ -402,15 +445,14 @@ impl<Fs: FileSystem + Default> ResolverGeneric<Fs> {
     }
 
     fn load_as_directory(&self, cached_path: &CachedPath, ctx: &mut Ctx) -> ResolveResult {
-        if !cached_path.is_dir(&self.cache.fs) {
-            return Ok(None);
-        }
         // TODO: Only package.json is supported, so warn about having other values
         // Checking for empty files is needed for omitting checks on package.json
         // 1. If X/package.json is a file,
         if !self.options.description_files.is_empty() {
             // a. Parse X/package.json, and look for "main" field.
-            if let Some(package_json) = cached_path.package_json(&self.cache.fs, &self.options)? {
+            if let Some(package_json) =
+                cached_path.package_json(&self.cache.fs, &self.options, ctx)?
+            {
                 // b. If "main" is a falsy value, GOTO 2.
                 for main_field in &package_json.main_fields {
                     // c. let M = X + (json main field)
@@ -440,15 +482,17 @@ impl<Fs: FileSystem + Default> ResolverGeneric<Fs> {
         ctx: &mut Ctx,
     ) -> ResolveResult {
         if self.options.resolve_to_context {
-            return Ok(cached_path.is_dir(&self.cache.fs).then(|| cached_path.clone()));
+            return Ok(cached_path.is_dir(&self.cache.fs, ctx).then(|| cached_path.clone()));
         }
         if !specifier.ends_with('/') {
             if let Some(path) = self.load_as_file(cached_path, ctx)? {
                 return Ok(Some(path));
             }
         }
-        if let Some(path) = self.load_as_directory(cached_path, ctx)? {
-            return Ok(Some(path));
+        if cached_path.is_dir(&self.cache.fs, ctx) {
+            if let Some(path) = self.load_as_directory(cached_path, ctx)? {
+                return Ok(Some(path));
+            }
         }
         Ok(None)
     }
@@ -529,7 +573,9 @@ impl<Fs: FileSystem + Default> ResolverGeneric<Fs> {
     }
 
     fn load_alias_or_file(&self, cached_path: &CachedPath, ctx: &mut Ctx) -> ResolveResult {
-        if let Some(package_json) = cached_path.find_package_json(&self.cache.fs, &self.options)? {
+        if let Some(package_json) =
+            cached_path.find_package_json(&self.cache.fs, &self.options, ctx)?
+        {
             if let Some(path) = self.load_browser_field(cached_path, None, &package_json, ctx)? {
                 return Ok(Some(path));
             }
@@ -541,9 +587,11 @@ impl<Fs: FileSystem + Default> ResolverGeneric<Fs> {
         {
             return Ok(Some(path));
         }
-        if cached_path.is_file(&self.cache.fs) {
+        if cached_path.is_file(&self.cache.fs, ctx) {
+            // ctx.add_file_dependency(cached_path.path());
             return Ok(Some(cached_path.clone()));
         }
+        // ctx.add_missing_dependency(cached_path.path());
         Ok(None)
     }
 
@@ -558,7 +606,13 @@ impl<Fs: FileSystem + Default> ResolverGeneric<Fs> {
         // 2. for each DIR in DIRS:
         for module_name in &self.options.modules {
             for cached_path in std::iter::successors(Some(cached_path), |p| p.parent()) {
-                let Some(cached_path) = self.get_module_directory(cached_path, module_name) else {
+                // Skip if /path/to/node_modules does not exist
+                if !cached_path.is_dir(&self.cache.fs, ctx) {
+                    continue;
+                }
+
+                let Some(cached_path) = self.get_module_directory(cached_path, module_name, ctx)
+                else {
                     continue;
                 };
                 // Optimize node_modules lookup by inspecting whether the package exists
@@ -569,7 +623,7 @@ impl<Fs: FileSystem + Default> ResolverGeneric<Fs> {
                     let package_path = cached_path.path().join(package_name);
                     let cached_path = self.cache.value(&package_path);
                     // Try foo/node_modules/package_name
-                    if cached_path.is_dir(&self.cache.fs) {
+                    if cached_path.is_dir(&self.cache.fs, ctx) {
                         // a. LOAD_PACKAGE_EXPORTS(X, DIR)
                         if let Some(path) =
                             self.load_package_exports(specifier, subpath, &cached_path, ctx)?
@@ -585,7 +639,7 @@ impl<Fs: FileSystem + Default> ResolverGeneric<Fs> {
                         // i.e. `foo/node_modules/@scope` is not a directory for `foo/node_modules/@scope/package`
                         if package_name.starts_with('@') {
                             if let Some(path) = cached_path.parent() {
-                                if !path.is_dir(&self.cache.fs) {
+                                if !path.is_dir(&self.cache.fs, ctx) {
                                     continue;
                                 }
                             }
@@ -610,13 +664,14 @@ impl<Fs: FileSystem + Default> ResolverGeneric<Fs> {
         &self,
         cached_path: &CachedPath,
         module_name: &str,
+        ctx: &mut Ctx,
     ) -> Option<CachedPath> {
         if cached_path.path().ends_with(module_name) {
             Some(cached_path.clone())
         } else if module_name == "node_modules" {
-            cached_path.cached_node_modules(&self.cache)
+            cached_path.cached_node_modules(&self.cache, ctx)
         } else {
-            cached_path.module_directory(module_name, &self.cache)
+            cached_path.module_directory(module_name, &self.cache, ctx)
         }
     }
 
@@ -629,7 +684,8 @@ impl<Fs: FileSystem + Default> ResolverGeneric<Fs> {
     ) -> ResolveResult {
         // 2. If X does not match this pattern or DIR/NAME/package.json is not a file,
         //    return.
-        let Some(package_json) = cached_path.package_json(&self.cache.fs, &self.options)? else {
+        let Some(package_json) = cached_path.package_json(&self.cache.fs, &self.options, ctx)?
+        else {
             return Ok(None);
         };
         // 3. Parse DIR/NAME/package.json, and look for "exports" field.
@@ -663,7 +719,8 @@ impl<Fs: FileSystem + Default> ResolverGeneric<Fs> {
     ) -> ResolveResult {
         // 1. Find the closest package scope SCOPE to DIR.
         // 2. If no scope was found, return.
-        let Some(package_json) = cached_path.find_package_json(&self.cache.fs, &self.options)?
+        let Some(package_json) =
+            cached_path.find_package_json(&self.cache.fs, &self.options, ctx)?
         else {
             return Ok(None);
         };
@@ -742,7 +799,7 @@ impl<Fs: FileSystem + Default> ResolverGeneric<Fs> {
         if ctx.resolving_alias.as_ref().is_some_and(|s| s == new_specifier) {
             // Complete when resolving to self `{"./a.js": "./a.js"}`
             if new_specifier.strip_prefix("./").filter(|s| path.ends_with(Path::new(s))).is_some() {
-                return if cached_path.is_file(&self.cache.fs) {
+                return if cached_path.is_file(&self.cache.fs, ctx) {
                     Ok(Some(cached_path.clone()))
                 } else {
                     Err(ResolveError::NotFound(new_specifier.to_string()))
@@ -967,7 +1024,8 @@ impl<Fs: FileSystem + Default> ResolverGeneric<Fs> {
         for module_name in &self.options.modules {
             for cached_path in std::iter::successors(Some(cached_path), |p| p.parent()) {
                 // 1. Let packageURL be the URL resolution of "node_modules/" concatenated with packageSpecifier, relative to parentURL.
-                let Some(cached_path) = self.get_module_directory(cached_path, module_name) else {
+                let Some(cached_path) = self.get_module_directory(cached_path, module_name, ctx)
+                else {
                     continue;
                 };
                 // 2. Set parentURL to the parent folder URL of parentURL.
@@ -975,10 +1033,10 @@ impl<Fs: FileSystem + Default> ResolverGeneric<Fs> {
                 let cached_path = self.cache.value(&package_path);
                 // 3. If the folder at packageURL does not exist, then
                 //   1. Continue the next loop iteration.
-                if cached_path.is_dir(&self.cache.fs) {
+                if cached_path.is_dir(&self.cache.fs, ctx) {
                     // 4. Let pjson be the result of READ_PACKAGE_JSON(packageURL).
                     if let Some(package_json) =
-                        cached_path.package_json(&self.cache.fs, &self.options)?
+                        cached_path.package_json(&self.cache.fs, &self.options, ctx)?
                     {
                         // 5. If pjson is not null and pjson.exports is not null or undefined, then
                         if !package_json.exports.is_empty() {
@@ -1002,7 +1060,7 @@ impl<Fs: FileSystem + Default> ResolverGeneric<Fs> {
                                 // 1. Return the URL resolution of main in packageURL.
                                 let path = cached_path.path().normalize_with(main_field);
                                 let cached_path = self.cache.value(&path);
-                                if cached_path.is_file(&self.cache.fs) {
+                                if cached_path.is_file(&self.cache.fs, ctx) {
                                     return Ok(Some(cached_path));
                                 }
                             }

--- a/src/tests/dependencies.rs
+++ b/src/tests/dependencies.rs
@@ -1,0 +1,86 @@
+//! https://github.com/webpack/enhanced-resolve/blob/main/test/dependencies.test.js
+
+use rustc_hash::FxHashSet;
+use std::path::PathBuf;
+
+use crate::{ResolveContext, ResolveOptions, ResolverGeneric};
+
+use super::memory_fs::MemoryFS;
+
+fn file_system() -> MemoryFS {
+    MemoryFS::new(&[
+        ("/a/b/node_modules/some-module/index.js", ""),
+        ("/a/node_modules/module/package.json", r#"{"main":"entry.js"}"#),
+        ("/a/node_modules/module/file.js", r#"{"main":"entry.js"}"#),
+        ("/modules/other-module/file.js", ""),
+    ])
+}
+
+#[test]
+#[cfg(not(target_os = "windows"))] // MemoryFS's path separator is always `/` so the test will not pass in windows.
+fn test() {
+    let file_system = file_system();
+
+    let resolver = ResolverGeneric::<MemoryFS>::new_with_file_system(
+        file_system,
+        ResolveOptions {
+            extensions: vec![".json".into(), ".js".into()],
+            modules: vec!["/modules".into(), "node_modules".into()],
+            ..ResolveOptions::default()
+        },
+    );
+
+    let data = [
+        (
+            "middle module request",
+            "/a/b/c",
+            "module/file",
+            "/a/node_modules/module/file.js",
+            // These dependencies are different from enhanced-resolve due to different code path to
+            // querying the file system
+            vec!["/a/node_modules/module/file.js", "/a/node_modules/module/package.json"],
+            vec![
+                "/a/b/c",
+                "/a/b/node_modules/module",
+                "/a/b/package.json",
+                "/a/node_modules/module/file",
+                "/a/node_modules/module/file.js",
+                "/a/node_modules/module/file.json",
+                "/a/package.json",
+                "/modules/module",
+                "/package.json",
+            ],
+        ),
+        (
+            "fast found module",
+            "/a/b/c",
+            "other-module/file.js",
+            "/modules/other-module/file.js",
+            // These dependencies are different from enhanced-resolve due to different code path to
+            // querying the file system
+            vec!["/modules/other-module/file.js"],
+            vec![
+                "/a/b/c",
+                "/a/b/package.json",
+                "/a/package.json",
+                "/modules/other-module/file.js",
+                "/modules/other-module/package.json",
+                "/modules/package.json",
+                "/package.json",
+            ],
+        ),
+    ];
+
+    for (name, context, request, result, file_dependencies, missing_dependencies) in data {
+        let mut ctx = ResolveContext::default();
+        let path = PathBuf::from(context);
+        let resolved =
+            resolver.resolve_with_context(path, request, &mut ctx).map(|r| r.full_path());
+        assert_eq!(resolved, Ok(PathBuf::from(result)));
+        let file_dependencies = FxHashSet::from_iter(file_dependencies.iter().map(PathBuf::from));
+        let missing_dependencies =
+            FxHashSet::from_iter(missing_dependencies.iter().map(PathBuf::from));
+        assert_eq!(ctx.file_dependencies, file_dependencies, "{name}");
+        assert_eq!(ctx.missing_dependencies, missing_dependencies, "{name}");
+    }
+}

--- a/src/tests/dependencies.rs
+++ b/src/tests/dependencies.rs
@@ -38,17 +38,31 @@ fn test() {
             "/a/node_modules/module/file.js",
             // These dependencies are different from enhanced-resolve due to different code path to
             // querying the file system
-            vec!["/a/node_modules/module/file.js", "/a/node_modules/module/package.json"],
             vec![
-                "/a/b/c",
-                "/a/b/node_modules/module",
-                "/a/b/package.json",
-                "/a/node_modules/module/file",
+                // found package.json
+                "/a/node_modules/module/package.json",
+                // symlink checks
                 "/a/node_modules/module/file.js",
-                "/a/node_modules/module/file.json",
+                // "/a/node_modules/module",
+                // "/a/node_modules",
+                // "/a",
+                // "/",
+            ],
+            vec![
+                // missing package.jsons
+                // "/a/b/c/package.json",
+                "/a/b/package.json",
                 "/a/package.json",
-                "/modules/module",
                 "/package.json",
+                // missing modules directories
+                "/a/b/c",
+                // "/a/b/c/node_modules",
+                // missing single file modules
+                "/modules/module",
+                "/a/b/node_modules/module",
+                // missing files with alternative extensions
+                "/a/node_modules/module/file",
+                "/a/node_modules/module/file.json",
             ],
         ),
         (
@@ -58,15 +72,22 @@ fn test() {
             "/modules/other-module/file.js",
             // These dependencies are different from enhanced-resolve due to different code path to
             // querying the file system
-            vec!["/modules/other-module/file.js"],
             vec![
+                // symlink checks
+                "/modules/other-module/file.js",
+                // "/modules/other-module",
+                // "/modules",
+                // "/",
+            ],
+            vec![
+                // missing package.jsons
+                // "/a/b/c/package.json",
                 "/a/b/c",
                 "/a/b/package.json",
                 "/a/package.json",
-                "/modules/other-module/file.js",
+                "/package.json",
                 "/modules/other-module/package.json",
                 "/modules/package.json",
-                "/package.json",
             ],
         ),
     ];

--- a/src/tests/extensions.rs
+++ b/src/tests/extensions.rs
@@ -1,6 +1,7 @@
 //! <https://github.com/webpack/enhanced-resolve/blob/main/test/extensions.test.js>
 
-use crate::{EnforceExtension, Resolution, ResolveError, ResolveOptions, Resolver};
+use crate::{EnforceExtension, Resolution, ResolveContext, ResolveError, ResolveOptions, Resolver};
+use rustc_hash::FxHashSet;
 
 #[test]
 fn extensions() {
@@ -44,14 +45,19 @@ fn extensions() {
 fn default_enforce_extension() {
     let f = super::fixture().join("extensions");
 
+    let mut ctx = ResolveContext::default();
     let resolved = Resolver::new(ResolveOptions {
         extensions: vec![".ts".into(), String::new(), ".js".into()],
         ..ResolveOptions::default()
     })
-    .resolve(&f, "./foo");
+    .resolve_with_context(&f, "./foo", &mut ctx);
 
     assert_eq!(resolved.map(Resolution::into_path_buf), Ok(f.join("foo.ts")));
-    // TODO: need to match missingDependencies returned from the resolve function
+    assert_eq!(
+        ctx.file_dependencies,
+        FxHashSet::from_iter([f.join("foo.ts"), f.join("package.json")])
+    );
+    assert_eq!(ctx.missing_dependencies, FxHashSet::from_iter([f.join("foo.ts")]));
 }
 
 // should respect enforceExtension when extensions includes an empty string
@@ -59,14 +65,20 @@ fn default_enforce_extension() {
 fn respect_enforce_extension() {
     let f = super::fixture().join("extensions");
 
+    let mut ctx = ResolveContext::default();
     let resolved = Resolver::new(ResolveOptions {
         enforce_extension: EnforceExtension::Disabled,
         extensions: vec![".ts".into(), String::new(), ".js".into()],
         ..ResolveOptions::default()
     })
-    .resolve(&f, "./foo");
+    .resolve_with_context(&f, "./foo", &mut ctx);
+
     assert_eq!(resolved.map(Resolution::into_path_buf), Ok(f.join("foo.ts")));
-    // TODO: need to match missingDependencies returned from the resolve function
+    assert_eq!(
+        ctx.file_dependencies,
+        FxHashSet::from_iter([f.join("foo.ts"), f.join("package.json")])
+    );
+    assert_eq!(ctx.missing_dependencies, FxHashSet::from_iter([f.join("foo"), f.join("foo.ts")]));
 }
 
 #[test]

--- a/src/tests/extensions.rs
+++ b/src/tests/extensions.rs
@@ -57,7 +57,7 @@ fn default_enforce_extension() {
         ctx.file_dependencies,
         FxHashSet::from_iter([f.join("foo.ts"), f.join("package.json")])
     );
-    assert_eq!(ctx.missing_dependencies, FxHashSet::from_iter([f.join("foo.ts")]));
+    assert!(ctx.missing_dependencies.is_empty());
 }
 
 // should respect enforceExtension when extensions includes an empty string
@@ -78,7 +78,7 @@ fn respect_enforce_extension() {
         ctx.file_dependencies,
         FxHashSet::from_iter([f.join("foo.ts"), f.join("package.json")])
     );
-    assert_eq!(ctx.missing_dependencies, FxHashSet::from_iter([f.join("foo"), f.join("foo.ts")]));
+    assert_eq!(ctx.missing_dependencies, FxHashSet::from_iter([f.join("foo")]));
 }
 
 #[test]

--- a/src/tests/missing.rs
+++ b/src/tests/missing.rs
@@ -1,0 +1,63 @@
+//! https://github.com/webpack/enhanced-resolve/blob/main/test/missing.test.js
+
+use crate::{ResolveContext, Resolver};
+
+#[test]
+fn test() {
+    let f = super::fixture();
+
+    let data = [
+        (
+            "./missing-file",
+            vec![f.join("missing-file"), f.join("missing-file.js"), f.join("missing-file.node")],
+        ),
+        (
+            "missing-module",
+            vec![
+                f.join("node_modules/missing-module"),
+                f.parent().unwrap().join("node_modules"), // enhanced-resolve is "node_modules/missing-module"
+            ],
+        ),
+        (
+            "missing-module/missing-file",
+            vec![
+                f.join("node_modules/missing-module"),
+                // f.parent().unwrap().join("node_modules/missing-module"), // we don't report this
+            ],
+        ),
+        (
+            "m1/missing-file",
+            vec![
+                f.join("node_modules/m1/missing-file"),
+                f.join("node_modules/m1/missing-file.js"),
+                f.join("node_modules/m1/missing-file.node"),
+                // f.parent().unwrap().join("node_modules/m1"), // we don't report this
+            ],
+        ),
+        (
+            "m1/",
+            vec![
+                f.join("node_modules/m1/index"),
+                f.join("node_modules/m1/index.js"),
+                f.join("node_modules/m1/index.json"),
+                f.join("node_modules/m1/index.node"),
+            ],
+        ),
+        ("m1/a", vec![f.join("node_modules/m1/a")]),
+    ];
+
+    let resolver = Resolver::default();
+
+    for (specifier, missing_dependencies) in data {
+        let mut ctx = ResolveContext::default();
+        let _ = resolver.resolve_with_context(&f, specifier, &mut ctx);
+
+        for dep in missing_dependencies {
+            assert!(
+                ctx.missing_dependencies.contains(&dep),
+                "{specifier}: {dep:?} not in {:?}",
+                &ctx.missing_dependencies
+            );
+        }
+    }
+}

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,6 +1,7 @@
 mod alias;
 mod browser_field;
 mod builtins;
+mod dependencies;
 mod exports_field;
 mod extension_alias;
 mod extensions;
@@ -10,6 +11,7 @@ mod imports_field;
 mod incorrect_description_file;
 mod main_field;
 mod memory_fs;
+mod missing;
 mod resolve;
 mod restrictions;
 mod roots;

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -67,5 +67,5 @@ fn dependencies() {
         &mut ctx,
     );
     assert!(!ctx.file_dependencies.is_empty());
-    assert!(!ctx.missing_dependencies.is_empty());
+    assert!(ctx.missing_dependencies.is_empty());
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -2,7 +2,7 @@
 
 use std::{env, path::PathBuf};
 
-use oxc_resolver::{Resolution, ResolveOptions, Resolver};
+use oxc_resolver::{Resolution, ResolveContext, ResolveOptions, Resolver};
 
 fn dir() -> PathBuf {
     env::current_dir().unwrap()
@@ -55,4 +55,17 @@ fn options() {
 fn debug_resolver() {
     let resolver = Resolver::new(ResolveOptions::default());
     assert!(!format!("{resolver:?}").is_empty());
+}
+
+#[test]
+fn dependencies() {
+    let path = dir();
+    let mut ctx = ResolveContext::default();
+    let _ = Resolver::new(ResolveOptions::default()).resolve_with_context(
+        path,
+        "./tests/package.json",
+        &mut ctx,
+    );
+    assert!(!ctx.file_dependencies.is_empty());
+    assert!(!ctx.missing_dependencies.is_empty());
 }


### PR DESCRIPTION
This PR adds:

* resolve_with_context API
* ResolveContext with file_dependencies and missing_dependencies

These dependencies are used for Rspack to control caching logic around module resolution.