### PR TITLE
fix: returning broken missing dependencies when alias and extensions are provided

### DIFF
--- a/src/tests/alias.rs
+++ b/src/tests/alias.rs
@@ -55,6 +55,7 @@ fn alias() {
                 ("alias_query".into(), vec![AliasValue::Path("a?query_after".into())]),
                 ("alias_fragment".into(), vec![AliasValue::Path("a#fragment_after".into())]),
                 ("dash".into(), vec![AliasValue::Ignore]),
+                ("@scope/package-name/file$".into(), vec![AliasValue::Path("/c/dir".into())]),
             ],
             modules: vec!["/".into()],
             ..ResolveOptions::default()
@@ -97,6 +98,7 @@ fn alias() {
         ("should resolve query in alias value", "alias_query?query_before", "/a/index?query_after"),
         ("should resolve query in alias value", "alias_fragment#fragment_before", "/a/index#fragment_after"),
         ("should resolve dashed name", "dashed-name", "/dashed-name"),
+        ("should resolve scoped package name with sub dir", "@scope/package-name/file", "/c/dir/index"),
     ];
 
     for (comment, request, expected) in pass {


### PR DESCRIPTION
Upstream: https://github.com/web-infra-dev/modern.js/issues/5227

Given the alias

```
'react-dom': '/node_modules/react-dom/index.js'
```

requesting `react-dom/client` would yield `/node_modules/react-dom/index.js/client.js`.

This creates a invalid missing dependency entry '/node_modules/react-dom/index.js/client.js',

for which watchpack will throw an error for `path.dirname(p)`,

```javascript
watchFile(p, startTime) {
    const directory = path.dirname(p);
    if (directory === p) return null;
    return this.getDirectoryWatcher(directory).watch(p, startTime);
}
```

https://github.com/webpack/watchpack/blob/dc690bbaea140820f1d9c7c2ec4dff8902798ff9/lib/getWatcherManager.js#L30